### PR TITLE
update gestational dm analysis

### DIFF
--- a/analysis/model/04_01_(a)_cox_fit_model.R
+++ b/analysis/model/04_01_(a)_cox_fit_model.R
@@ -203,8 +203,8 @@ coxfit <- function(data_surv, interval_names, covar_names, reduced_covar_names, 
       }
     }
 
-    #If subgroup is not sex then add sex into formula
-    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age)){
+    #If subgroup is not sex then add sex into formula - also do not add sex if event name is gestational dm (analyses performed in women only)
+    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age) & event_name != "out_date_gestationaldm"){
       surv_formula <- paste(surv_formula, "sex", sep="+")
     }
 

--- a/analysis/model/04_01_(a)_cox_fit_model.R
+++ b/analysis/model/04_01_(a)_cox_fit_model.R
@@ -204,7 +204,7 @@ coxfit <- function(data_surv, interval_names, covar_names, reduced_covar_names, 
     }
 
     #If subgroup is not sex then add sex into formula - also do not add sex if event name is gestational dm (analyses performed in women only)
-    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age) & (event_name != "out_date_gestationaldm")){
+    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age) & (event_name != "gestationaldm")){
       surv_formula <- paste(surv_formula, "sex", sep="+")
     }
 

--- a/analysis/model/04_01_(a)_cox_fit_model.R
+++ b/analysis/model/04_01_(a)_cox_fit_model.R
@@ -204,7 +204,7 @@ coxfit <- function(data_surv, interval_names, covar_names, reduced_covar_names, 
     }
 
     #If subgroup is not sex then add sex into formula - also do not add sex if event name is gestational dm (analyses performed in women only)
-    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age) & event_name != "out_date_gestationaldm"){
+    if ((startsWith(subgroup,"sex"))==F & (!"sex" %in% covariates_excl_region_sex_age) & (event_name != "out_date_gestationaldm")){
       surv_formula <- paste(surv_formula, "sex", sep="+")
     }
 


### PR DESCRIPTION
New model code adds in sex as a covariate to all analyses. As a result of this the gestational dm cox action failed as the model did not converge (analyses for gestational dm are performed in women only). 
This PR adds an IF statement to not add the sex covariate back in if the event name is gestational dm. 