### PR TITLE
Add episode event counts

### DIFF
--- a/analysis/cox_model.do
+++ b/analysis/cox_model.do
@@ -9,9 +9,15 @@
 	   Other output:			logfiles
    -----------------------------------------------------------------------------*/
 
+local cpf "input_sampled_data_t2dm_rec_main_prevax_normal_time_periods"
+local day0 "TRUE"
+local extf "FALSE"
+   
+/* 
 local cpf "`1'"
 local day0 "`2'"
 local extf "`3'"
+*/
 
 * Set file paths
 
@@ -280,12 +286,13 @@ estout * using "output/`cpf'_cox_model_day0`day0'_extf`extf'.txt", cells("b se t
 
 keep if outcome_status==1
 keep patient_id days* follow_up
+rename follow_up tte
 gen term = ""
 
 if `prevax_cohort'==1 {
 	if "`extf'"=="TRUE" {
 		if "`day0'"=="TRUE" {
-			drop if days0_1==0 & days1_28==0 & days28_197==0 & days197_365==0 & days365_714==0
+			replace term = "days_pre" if days0_1==0 & days1_28==0 & days28_197==0 & days197_365==0 & days365_714==0
 			replace term = "days0_1" if days0_1==1 & days1_28==0 & days28_197==0 & days197_365==0 & days365_714==0
 			replace term = "days1_28" if days0_1==0 & days1_28==1 & days28_197==0 & days197_365==0 & days365_714==0
 			replace term = "days28_197" if days0_1==0 & days1_28==0 & days28_197==1 & days197_365==0 & days365_714==0
@@ -293,7 +300,7 @@ if `prevax_cohort'==1 {
 			replace term = "days365_714" if days0_1==0 & days1_28==0 & days28_197==0 & days197_365==0 & days365_714==1
 		}
 		else {
-			drop if days0_28==0 & days28_197==0 & days197_365==0 & days365_714==0
+			replace term = "days_pre" if days0_28==0 & days28_197==0 & days197_365==0 & days365_714==0
 			replace term = "days0_28" if days0_28==1 & days28_197==0 & days197_365==0 & days365_714==0
 			replace term = "days28_197" if days0_28==0 & days28_197==1 & days197_365==0 & days365_714==0
 			replace term = "days197_365" if days0_28==0 & days28_197==0 & days197_365==1 & days365_714==0
@@ -302,14 +309,14 @@ if `prevax_cohort'==1 {
 	} 
 	else {
 		if "`day0'"=="TRUE" {
-			drop if days0_1==0 & days1_28==0 & days28_197==0 & days197_535==0
+			replace term = "days_pre" if days0_1==0 & days1_28==0 & days28_197==0 & days197_535==0
 			replace term = "days0_1" if days0_1==1 & days1_28==0 & days28_197==0 & days197_535==0	
 			replace term = "days1_28" if days0_1==0 & days1_28==1 & days28_197==0 & days197_535==0	
 			replace term = "days28_197" if days0_1==0 & days1_28==0 & days28_197==1 & days197_535==0	
 			replace term = "days197_365" if days0_1==0 & days1_28==0 & days28_197==0 & days197_535==1	
 		}
 		else {
-			drop if days0_28==0 & days28_197==0 & days197_535==0	
+			replace term = "days_pre" if days0_28==0 & days28_197==0 & days197_535==0	
 			replace term = "days0_28" if days0_28==1 & days28_197==0 & days197_535==0
 			replace term = "days28_197" if days0_28==0 & days28_197==1 & days197_535==0
 			replace term = "days197_535" if days0_28==0 & days28_197==0 & days197_535==1 
@@ -318,27 +325,27 @@ if `prevax_cohort'==1 {
 } 
 else {
 	if "`day0'"=="TRUE" {
-		drop if days0_1==0 & days1_28==0 & days28_197==0
+		replace term = "days_pre" if days0_1==0 & days1_28==0 & days28_197==0
 		replace term = "days0_1" if days0_1==1 & days1_28==0 & days28_197==0
 		replace term = "days1_28" if days0_1==0 & days1_28==1 & days28_197==0	
 		replace term = "days28_197" if days0_1==0 & days1_28==0 & days28_197==1
 	}
 	else {
-		drop if days0_28==0 & days28_197==0
+		replace term = "days_pre" if days0_28==0 & days28_197==0
 		replace term = "days0_28" if days0_28==1 & days28_197==0
 		replace term = "days28_197" if days0_28==0 & days28_197==1
 		replace term = "days197_535" if days0_28==0 & days28_197==0
-		replace follow_up = follow_up + 197 if term == "days197_535" 
 	}
 }
 
-replace follow_up = follow_up + 28 if term == "days28_197"
-replace follow_up = follow_up + 197 if term == "days197_365"
-replace follow_up = follow_up + 365 if term == "days365_714"
-replace follow_up = follow_up + 197 if term == "days197_535"
-bysort term: egen medianfup = median(follow_up)
+replace tte = tte + 28 if term == "days28_197"
+replace tte = tte + 197 if term == "days197_365"
+replace tte = tte + 365 if term == "days365_714"
+replace tte = tte + 197 if term == "days197_535"
+bysort term: egen median_tte = median(tte)
+egen events = count(patient_id), by(term)
 
-keep term medianfup
+keep term median_tte events
 duplicates drop
 
 export delimited using "output/`cpf'_stata_median_fup_day0`day0'_extf`extf'", replace

--- a/analysis/cox_model.do
+++ b/analysis/cox_model.do
@@ -9,15 +9,9 @@
 	   Other output:			logfiles
    -----------------------------------------------------------------------------*/
 
-local cpf "input_sampled_data_t2dm_rec_main_prevax_normal_time_periods"
-local day0 "TRUE"
-local extf "FALSE"
-   
-/* 
 local cpf "`1'"
 local day0 "`2'"
 local extf "`3'"
-*/
 
 * Set file paths
 

--- a/analysis/format_stata_output.R
+++ b/analysis/format_stata_output.R
@@ -86,7 +86,7 @@ for (f in files) {
   f <- gsub("_cox_model_","_stata_median_fup_",f)
   f <- gsub(".txt",".csv",f)
   fup <- readr::read_csv(file = paste0("output/",f))
-  tmp <- merge(tmp, fup, by = "term", all.x = TRUE)
+  tmp <- merge(tmp, fup, by = "term", all = TRUE)
   
   ## Apend to master dataframe
     
@@ -96,7 +96,7 @@ for (f in files) {
 
 # Format master dataframe
 
-df <- df[,c("source","term","medianfup",
+df <- df[,c("source","term","median_tte","events",
             paste0(c("b","se","t","lci","uci","p","persondays","outcomes","subjects","observations","clusters"),"_min"),
             paste0(c("b","se","t","lci","uci","p","persondays","outcomes","subjects","observations","clusters"),"_max"))]
 
@@ -109,7 +109,7 @@ df <- tidyr::pivot_longer(df,
                           values_to = "value")
 
 df <- tidyr::pivot_wider(df, 
-                         id_cols = c("source","term", "model","medianfup"),
+                         id_cols = c("source","term", "model","median_tte","events"),
                          names_from = "stat", 
                          values_from = "value")
 
@@ -119,7 +119,7 @@ df <- df[df$model=="max" | (df$model=="min" & df$term %in% c(unique(df$term)[gre
                                                              "1.sex","2.sex","age_spline1","age_spline2")),]
 
 df <- df[order(df$source, df$model),
-         c("source","term","model","b","lci","uci","se","medianfup","subjects","outcomes")]
+         c("source","term","model","b","lci","uci","se","median_tte","events","subjects","outcomes")]
 
 df <- dplyr::rename(df,
                     "estimate" = "b",
@@ -127,7 +127,8 @@ df <- dplyr::rename(df,
                     "conf_high" = "uci",
                     "se_ln_hr" = "se",
                     "N_sample_size" = "subjects",
-                    "median_follow_up" = "medianfup",
+                    "median_time_to_event" = "median_tte",
+                    "N_outcomes_episode" = "events",
                     "N_outcomes" = "outcomes")
 
 # Save output ------------------------------------------------------------------


### PR DESCRIPTION
Updated the Stata code to add episode event counts. I have also renamed 'medianfup' to 'median_tte' as I added a 'days_pre' category. I felt this was necessary because follow-up (fup) and time to event (tte) are the same for post-covid exposure episodes but differ for 'days_pre' as follow-up will include people without an event who are not considered in this code.