### PR TITLE
update table 2 and aer script

### DIFF
--- a/analysis/descriptives/excess_t2dm_events.R
+++ b/analysis/descriptives/excess_t2dm_events.R
@@ -43,7 +43,7 @@ table_2$event <- gsub("_extended_follow_up","",table_2$event)
 table_2 <- table_2 %>% select(event, subgroup, cohort, total_person_days, unexposed_person_days,total_person_days_to_day_197) %>% 
   filter(subgroup %in% c("covid_pheno_hospitalised","covid_pheno_non_hospitalised"))
 
-table_2$exposed_person_days <- ifelse(table_2$cohort != "pre_vaccination", table_2$total_person_days - table_2$unexposed_person_days, table_2$total_person_days_to_day_197)
+table_2$exposed_person_days <- ifelse(table_2$cohort != "prevax", table_2$total_person_days - table_2$unexposed_person_days, table_2$total_person_days_to_day_197)
 table_2$total_person_days <- NULL
 table_2$unexposed_person_days <- NULL
 table_2$total_person_days_to_day_197 <- NULL

--- a/analysis/descriptives/excess_t2dm_events.R
+++ b/analysis/descriptives/excess_t2dm_events.R
@@ -34,18 +34,19 @@ table2_pre_vax <- dplyr::rename(table2_pre_vax, cohort = cohort_to_run)
 table2_vax <- dplyr::rename(table2_vax, cohort = cohort_to_run)
 table2_unvax <- dplyr::rename(table2_unvax, cohort = cohort_to_run)
 
-table_2 <- rbind(table2_pre_vax, table2_vax,table2_unvax)
+table_2 <- plyr::rbind.fill(table2_pre_vax, table2_vax,table2_unvax)
 rm(table2_pre_vax,table2_vax,table2_unvax)
 
 table_2$event <- gsub("_extended_follow_up","",table_2$event)
 
 #To get total follow up for main analysis need to sum unexposed person days of follow up & exposed person days
-table_2 <- table_2 %>% select(event, subgroup, cohort, total_person_days, unexposed_person_days) %>% 
+table_2 <- table_2 %>% select(event, subgroup, cohort, total_person_days, unexposed_person_days,total_person_days_to_day_197) %>% 
   filter(subgroup %in% c("covid_pheno_hospitalised","covid_pheno_non_hospitalised"))
 
-table_2$exposed_person_days <- table_2$total_person_days - table_2$unexposed_person_days
+table_2$exposed_person_days <- ifelse(table_2$cohort != "pre_vaccination", table_2$total_person_days - table_2$unexposed_person_days, table_2$total_person_days_to_day_197)
 table_2$total_person_days <- NULL
 table_2$unexposed_person_days <- NULL
+table_2$total_person_days_to_day_197 <- NULL
 
 #Sum follow up
 table_2 <- table_2 %>% group_by(event, cohort) %>%

--- a/analysis/descriptives/table_2.R
+++ b/analysis/descriptives/table_2.R
@@ -209,6 +209,7 @@ table_2_subgroups_output <- function(cohort_name, group){
     analyses_of_interest$day_0_event_counts[i] <- table2_output[[5]]
     analyses_of_interest$total_covid19_cases[i] <- table2_output[[6]]
     analyses_of_interest$N_population_size[i] <- table2_output[[7]]
+    analyses_of_interest$person_days_total_exposed_to_day_197 <- table2_output[[8]]
   
     
     setnames(survival_data,
@@ -339,6 +340,11 @@ table_2_calculation <- function(survival_data, event,cohort,subgroup, stratify_b
   person_days_total_unexposed  = round(sum(data_active$person_days_unexposed, na.rm = TRUE),1)
   person_days_total = round(sum(data_active$person_days, na.rm = TRUE),1)
   
+  #calculate post exposure follow-up up to day 197 for AER calculation
+  data_active$person_days_exposed_day_197 <- data_active$person_days - data_active$person_days_unexposed
+  data_active$person_days_exposed_day_197 <- ifelse(data_active$person_days_exposed_day_197 > 197, 197,data_active$person_days_exposed_day_197)
+  person_days_total_exposed_to_day_197 = round(sum(data_active$person_days_exposed_day_197, na.rm = TRUE),1)
+  
   # calculate total covid cases for aer
   total_covid_cases <- nrow(data_active %>% filter(!is.na(exp_date_covid19_confirmed)))
   
@@ -370,7 +376,7 @@ table_2_calculation <- function(survival_data, event,cohort,subgroup, stratify_b
     event_count_exposed <- "[Redacted]"
   }
   
-  return(list(person_days_total_unexposed, event_count_unexposed, event_count_exposed, person_days_total, day_0_event_count, total_covid_cases, N_population_size))
+  return(list(person_days_total_unexposed, event_count_unexposed, event_count_exposed, person_days_total, day_0_event_count, total_covid_cases, N_population_size, person_days_total_exposed_to_day_197))
 }
 
 


### PR DESCRIPTION
- Add person day of follow-up post covid up to day 197 for AER
- Update AER script to use the above for the pre-vaccination cohort

**This has not been tested locally**
I don't have up-to-date diabetes dummy data saved locally so the table 2 script doesn't run for me (I've been re-running but it hasn't finished in time). These are only small changes that look like they should be fine but please check on dummy data if possible

Pre-vax CVD code for reference:
Follow-up to day 197: https://github.com/opensafely/post-covid-pre-vaccinated-cardiovascular/blob/bf7beb1eeee48da5bb6771eab293ae00454ff4b4/analysis/descriptives/table_2.R#L311
&
https://github.com/opensafely/post-covid-pre-vaccinated-cardiovascular/blob/bf7beb1eeee48da5bb6771eab293ae00454ff4b4/analysis/descriptives/table_2.R#L325

Commit that updated the AER script to use updated tabled 2: https://github.com/opensafely/post-covid-vaccinated/commit/8c1f1029d74685fb94d32ffd979774c99d7e64d7