### PR TITLE
update 4 month follow up outcomes

### DIFF
--- a/analysis/descriptives/table_2.R
+++ b/analysis/descriptives/table_2.R
@@ -83,6 +83,22 @@ table_2_subgroups_output <- function(cohort_name, group){
            new = c("sex",
                    "ethnicity"))
   
+  # Add extra columns for persistent diabetes and diabetes with 4 months follow up
+  
+  if (cohort_name == "prevax" & group == "diabetes") {
+    for(i in c("out_date_t2dm_follow","out_date_t2dm_follow_extended_follow_up","out_date_t2dm_4months_follow_up_no_cox_only_table_2","out_date_t2dm_4months_follow_up_no_cox_only_table_2_extended_follow_up")){
+      outcome_name_short <- gsub("out_date_","",i)
+      replace_outcome <- ifelse(outcome_name_short %in% c("t2dm_follow", "t2dm_4months_follow_up_no_cox_only_table_2"), "t2dm", "t2dm_extended_follow_up")
+      
+      survival_data[paste0(outcome_name_short,"_follow_up_end_unexposed")] <- survival_data[paste0(replace_outcome,"_follow_up_end_unexposed")]
+      survival_data[paste0(outcome_name_short,"_follow_up_end")] <- survival_data[paste0(replace_outcome,"_follow_up_end")]
+      survival_data[paste0(outcome_name_short,"_hospitalised_follow_up_end")] <- survival_data[paste0(replace_outcome,"_hospitalised_follow_up_end")]
+      survival_data[paste0(outcome_name_short,"_non_hospitalised_follow_up_end")] <- survival_data[paste0(replace_outcome,"_non_hospitalised_follow_up_end")]
+      survival_data[paste0(outcome_name_short,"_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_follow_up_end_unexposed")]
+      survival_data[paste0(outcome_name_short,"_non_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_follow_up_end_unexposed")]
+    }
+  }
+  
   #-----------------------Add in age groups category----------------------------
   setDT(survival_data)[ , agegroup := cut(cov_num_age, 
                                           breaks = agebreaks, 
@@ -92,23 +108,6 @@ table_2_subgroups_output <- function(cohort_name, group){
   for(i in outcomes){
     
     # RENAME END DATES FOR T2DM FOLLOW ANALYSIS -------------------------------
-    
-    if (i == "out_date_t2dm_follow" | i == "out_date_t2dm_follow_extended_follow_up") {
-      
-      survival_data$t2dm_follow_follow_up_end_unexposed <- survival_data$t2dm_follow_up_end_unexposed
-      survival_data$t2dm_follow_follow_up_end <- survival_data$t2dm_follow_up_end
-      survival_data$t2dm_follow_hospitalised_follow_up_end <- survival_data$t2dm_hospitalised_follow_up_end
-      survival_data$t2dm_follow_non_hospitalised_follow_up_end <- survival_data$t2dm_non_hospitalised_follow_up_end
-      survival_data$t2dm_follow_hospitalised_date_expo_censor <- survival_data$t2dm_hospitalised_date_expo_censor
-      survival_data$t2dm_follow_non_hospitalised_date_expo_censor <- survival_data$t2dm_non_hospitalised_date_expo_censor
-      survival_data$t2dm_follow_extended_follow_up_follow_up_end_unexposed <- survival_data$t2dm_extended_follow_up_follow_up_end_unexposed
-      survival_data$t2dm_follow_extended_follow_up_follow_up_end <- survival_data$t2dm_extended_follow_up_follow_up_end
-      survival_data$t2dm_follow_extended_follow_up_hospitalised_follow_up_end <- survival_data$t2dm_extended_follow_up_hospitalised_follow_up_end
-      survival_data$t2dm_follow_extended_follow_up_non_hospitalised_follow_up_end <- survival_data$t2dm_extended_follow_up_non_hospitalised_follow_up_end
-      survival_data$t2dm_follow_extended_follow_up_hospitalised_date_expo_censor <- survival_data$t2dm_extended_follow_up_hospitalised_date_expo_censor
-      survival_data$t2dm_follow_extended_follow_up_non_hospitalised_date_expo_censor <- survival_data$t2dm_extended_follow_up_non_hospitalised_date_expo_censor
-      
-    }
     
     analyses_to_run <- active_analyses %>% filter(outcome_variable==i)
     
@@ -157,6 +156,15 @@ table_2_subgroups_output <- function(cohort_name, group){
   
   analyses_of_interest$strata[analyses_of_interest$strata=="South_Asian"]<- "South Asian"
   analyses_of_interest <- analyses_of_interest %>% filter(cohort_to_run == cohort_name)
+  
+  analyses_of_interest <- as.data.frame(analyses_of_interest)
+  
+  if(cohort_name == "prevax" & group == "diabetes"){
+    analyses_of_interest[nrow(analyses_of_interest)+1,] <- c("covid_pheno_hospitalised","out_date_t2dm_4months_follow_up_no_cox_only_table_2","prevax","covid_pheno_hospitalised","hospitalised")
+    analyses_of_interest[nrow(analyses_of_interest)+1,] <- c("covid_pheno_non_hospitalised","out_date_t2dm_4months_follow_up_no_cox_only_table_2","prevax","covid_pheno_non_hospitalised","non_hospitalised")
+    analyses_of_interest[nrow(analyses_of_interest)+1,] <- c("covid_pheno_hospitalised","out_date_t2dm_4months_follow_up_no_cox_only_table_2_extended_follow_up","prevax","covid_pheno_hospitalised","hospitalised")
+    analyses_of_interest[nrow(analyses_of_interest)+1,] <- c("covid_pheno_non_hospitalised","out_date_t2dm_4months_follow_up_no_cox_only_table_2_extended_follow_up","prevax","covid_pheno_non_hospitalised","non_hospitalised")
+    }
   
   #-----------------Add subgroup category for low count redaction---------------
   analyses_of_interest <- analyses_of_interest %>% 

--- a/analysis/descriptives/table_2.R
+++ b/analysis/descriptives/table_2.R
@@ -94,8 +94,8 @@ table_2_subgroups_output <- function(cohort_name, group){
       survival_data[paste0(outcome_name_short,"_follow_up_end")] <- survival_data[paste0(replace_outcome,"_follow_up_end")]
       survival_data[paste0(outcome_name_short,"_hospitalised_follow_up_end")] <- survival_data[paste0(replace_outcome,"_hospitalised_follow_up_end")]
       survival_data[paste0(outcome_name_short,"_non_hospitalised_follow_up_end")] <- survival_data[paste0(replace_outcome,"_non_hospitalised_follow_up_end")]
-      survival_data[paste0(outcome_name_short,"_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_follow_up_end_unexposed")]
-      survival_data[paste0(outcome_name_short,"_non_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_follow_up_end_unexposed")]
+      survival_data[paste0(outcome_name_short,"_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_hospitalised_date_expo_censor")]
+      survival_data[paste0(outcome_name_short,"_non_hospitalised_date_expo_censor")] <- survival_data[paste0(replace_outcome,"_non_hospitalised_date_expo_censor")]
     }
   }
   


### PR DESCRIPTION
Persistent diabetes outcome is where patients have 4 months of follow-up following diabetes diagnoses (i.e. time between diagnoses date (out_date_t2dm) and end date is >= 4 months) and were still being treated or had elevated HbA1c levels.

Previously the 4 months of follow up was being calculated using '18-06-21' which means that not all extended_follow_up outcomes (with study end date '14-12-21') were being captured. This has been updated so that out_date_t2dm_follow (persistent diabetes) uses '18-06-21' and out_date_t2dm_follow_extended_follow_up (persistent diabetes w/ extended follow up) uses '14-12-21'. This has increased the number of out_date_t2dm_follow_extended_follow_up events.

Add type 2 diabetes with 4 months follow up outcomes as these are needed for table 2 (these outcomes are not run with the cox scripts).

Update table 2 to run the additional outcomes (end date columns do not need to change as these outcomes are just subsets of t2dm and t2dm_extended_follow_up so their end date columns are copied and renamed).